### PR TITLE
fix: lock sidebar max width to 40ch

### DIFF
--- a/src/components/details-sidebar/styles.css
+++ b/src/components/details-sidebar/styles.css
@@ -1,11 +1,13 @@
 .sidebar {
   position: fixed;
+  box-sizing: border-box;
   top: 0;
   right: 0px;
   transition: right 0.5s;
   width: 40%;
-  min-width: 400px;
+  max-width: 40ch;
   height: 100vh;
+  overflow: auto;
   background: white;
   box-shadow: -2px 0px 5px 0 rgba(33,33,33,0.2);
   padding: 20px;


### PR DESCRIPTION
## Description

This PR adjusts the sizing of the sidebar to prevent it from growing beyond 40 characters wide. This should solve the problem of the sidebar being unnecessarily wide on larger screen sizes.

## Related issue

Closes #32