### PR TITLE
FIX: typo in RET_condition description

### DIFF
--- a/src/generators/call-and-return/RET_condition.js
+++ b/src/generators/call-and-return/RET_condition.js
@@ -32,7 +32,7 @@ const generate_RET_condition = () => { // eslint-disable-line camelcase
             in the lower-order byte of PC, and the contents of SP are incremented by 1.
             The contents of the address specified by the new SP value are then loaded
             in the higher-order byte of PC, and the contents of SP are incremented by 1
-            again. (THe value of SP is 2 larger than before instruction execution.)
+            again. (The value of SP is 2 larger than before instruction execution.)
             The next instruction is fetched from the address specified by the content
             of PC (as usual).
           </p>


### PR DESCRIPTION
Fixed a small capitalization typo in the description of conditional return opcodes.