### PR TITLE
fix: typo in description of return opcode

### DIFF
--- a/src/generators/call-and-return/RET.js
+++ b/src/generators/call-and-return/RET.js
@@ -18,7 +18,7 @@ const generate_RET = () => { // eslint-disable-line camelcase
     <>
       <p>
         Pop from the memory stack the program counter PC value pushed when the
-        subroutine was called, returning contorl to the source program.
+        subroutine was called, returning control to the source program.
       </p>
       <p>
         The contents of the address specified by the stack pointer SP are loaded

--- a/src/generators/call-and-return/RST_t3.js
+++ b/src/generators/call-and-return/RST_t3.js
@@ -41,8 +41,8 @@ const generate_RST_t3 = () => { // eslint-disable-line camelcase
         <p>
           {
             'The RST instruction can be used to jump to 1 of 8 addresses. Because all of'
-            + 'the addresses are held in page 0 memory, 0x00 is loaded in the higher-order'
-            + `byte of the PC, and 0x${addrOfTthByteInPage0Hex} is loaded in the lower-order byte.`
+            + ' the addresses are held in page 0 memory, 0x00 is loaded in the higher-order'
+            + ` byte of the PC, and 0x${addrOfTthByteInPage0Hex} is loaded in the lower-order byte.`
           }
         </p>
       </>


### PR DESCRIPTION
Fixed a typo and added some missing spaces.