### PR TITLE
Prevent first column from expanding when privacy policy is expanded

### DIFF
--- a/src/components/op-code-table/styles.css
+++ b/src/components/op-code-table/styles.css
@@ -1,7 +1,6 @@
 .op-code-table {
   border-collapse: collapse;
   background-color: #9F9F9F;
-  width: 100%;
 }
 
 .op-code-table tbody {


### PR DESCRIPTION
Currently, expanding the privacy policy on certain screen sizes or zoom levels will also expand the width of the 1st column of the op tablem, removing width: 100% from the table class should fix it

https://github.com/meganesu/generate-gb-opcodes/assets/8981287/59bbdc4d-3563-4f31-b017-669f8684eb7d

